### PR TITLE
Calculate the timeout using now as a reference

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -347,8 +347,9 @@ export class OAuthService extends AuthConfig {
     }
 
     protected calcTimeout(storedAt: number, expiration: number): number {
-        const delta = (expiration - storedAt) * this.timeoutFactor;
-        return delta;
+        const now = Date.now();
+        const delta = (expiration - storedAt) * this.timeoutFactor - (now - storedAt);
+        return Math.max(0, delta);
     }
 
     /**


### PR DESCRIPTION
If we don't do this, we could wait too long after a refresh of the app. We still use the storedAt variable to determine when we are in the last chunk (gray zone) of time (using the timeoutFactor), en make negative Delta's 0 (zero).